### PR TITLE
added mandatory name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All you need to do is to create a yaml file describing which chart you want to t
 chart: jenkins
 version: 2.0.0
 repository: https://kubernetes-charts.storage.googleapis.com
+name: jenkins
 ```
 
 or
@@ -29,6 +30,7 @@ chart: syncier-jenkins
 version: 5.6.0
 repository: https://hub.syncier.cloud/chartrepo/library/charts
 namespace: jenkins
+name: jenkins
 values:
   - values1.yaml
   - values2.yaml
@@ -40,7 +42,7 @@ Then you can run `helmt helm-charts.yaml` and it will download the chart and ren
 helm version
 version.BuildInfo{Version:"v3.1.1", GitCommit:"afe70585407b420d0097d07b21c47dc511525ac8", GitTreeState:"clean", GoVersion:"go1.13.8"}
 helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.0.0.tgz
-helm template --output-dir . jenkins-2.0.0.tgz
+helm template jenkins --output-dir . jenkins-2.0.0.tgz
 wrote ./jenkins/templates/service-account.yaml
 wrote ./jenkins/templates/secret.yaml
 wrote ./jenkins/templates/config.yaml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -45,20 +44,14 @@ values:
 namespace and values are optional
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("missing filename")
+		filename := "helm-chart.yaml"
+
+		fmt.Printf("templating '%s'\n", filename)
+		if len(args) == 1 {
+			filename = args[0]
 		}
 
-		err := helmt.HelmVersion()
-		if err != nil {
-			return err
-		}
-		err = helmt.HelmTemplate(args[0])
-		if err != nil {
-			return nil
-		}
-
-		return nil
+		return helmt.HelmTemplate(filename)
 	},
 }
 
@@ -67,7 +60,6 @@ namespace and values are optional
 func Execute(version string) {
 	rootCmd.Version = version
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -51,6 +51,12 @@ func HelmTemplate(filename string) error {
 	if err != nil {
 		return err
 	}
+
+	err = HelmVersion()
+	if err != nil {
+		return err
+	}
+
 	err = fetch(chart.Repository, chart.Chart, chart.Version)
 	if err != nil {
 		return err

--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -23,6 +23,7 @@ type HelmChart struct {
 	Chart      string   `yaml:"chart" validate:"required"`
 	Version    string   `yaml:"version" validate:"required"`
 	Repository string   `yaml:"repository" validate:"required"`
+	Name       string   `yaml:"name" validate:"required"`
 	Namespace  string   `yaml:"namespace"`
 	Values     []string `yaml:"values"`
 }
@@ -56,16 +57,19 @@ func HelmTemplate(filename string) error {
 	}
 
 	chartVersion := fmt.Sprintf("%s-%s.tgz", chart.Chart, chart.Version)
-	return template(chartVersion, chart.Values, chart.Namespace)
+	return template(chartVersion, chart.Name, chart.Values, chart.Namespace)
 }
 
 func HelmVersion() error {
 	return Execute("helm", "version")
 }
 
-func template(chartVersion string, values []string, namespace string) error {
+func template(chartVersion string, release string, values []string, namespace string) error {
 	//return Execute("helm", "template", "--namespace", namespace, "--values", values[0], "--output-dir", ".", chartVersion)
 	args := []string{"template"}
+	if len(release) > 0 {
+		args = append(args, release)
+	}
 	if len(namespace) > 0 {
 		args = append(args, "--namespace", namespace)
 	}

--- a/pkg/helmt/helmt_test.go
+++ b/pkg/helmt/helmt_test.go
@@ -85,6 +85,13 @@ func Test_readParameters(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "missing release",
+			args: args{
+				filename: "testdata/helm-chart-missing-release.yaml",
+			},
+			wantErr: true,
+		},
+		{
 			name: "file with mandatory parameters only",
 			args: args{
 				filename: "testdata/helm-chart-mandatory-parameters.yaml",
@@ -93,6 +100,7 @@ func Test_readParameters(t *testing.T) {
 				Chart:      "jenkins",
 				Version:    "2.0.0",
 				Repository: "https://kubernetes-charts.storage.googleapis.com",
+				Name:       "something",
 			},
 		},
 		{
@@ -104,6 +112,7 @@ func Test_readParameters(t *testing.T) {
 				Chart:      "stable/jenkins",
 				Version:    "2.0.0",
 				Repository: "https://kubernetes-charts.storage.googleapis.com",
+				Name:       "my-jenkins",
 			},
 		},
 		{
@@ -116,6 +125,7 @@ func Test_readParameters(t *testing.T) {
 				Version:    "5.6.0",
 				Repository: "https://hub.syncier.cloud/chartrepo/library/charts",
 				Namespace:  "jenkins",
+				Name:       "jenkins",
 				Values:     []string{"values1.yaml", "values2.yaml"},
 			},
 		},
@@ -151,18 +161,26 @@ func TestHelmTemplate(t *testing.T) {
 			},
 			expectedCommands: []string{
 				"helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.0.0.tgz",
-				"helm template --output-dir . jenkins-2.0.0.tgz",
+				"helm template something --output-dir . jenkins-2.0.0.tgz",
 			},
 		},
 		{
-			name: "helm template with namespace",
+			name: "helm template with namespace and release",
 			args: args{
 				filename: "testdata/helm-chart.yaml",
 			},
 			expectedCommands: []string{
 				"helm fetch https://hub.syncier.cloud/chartrepo/library/charts/syncier-jenkins-5.6.0.tgz",
-				"helm template --namespace jenkins --values values1.yaml --values values2.yaml --output-dir . syncier-jenkins-5.6.0.tgz",
+				"helm template jenkins --namespace jenkins --values values1.yaml --values values2.yaml --output-dir . syncier-jenkins-5.6.0.tgz",
 			},
+		},
+		{
+			name: "helm template with namespace and release",
+			args: args{
+				filename: "testdata/helm-chart-missing-release.yaml",
+			},
+			expectedCommands: []string{},
+			wantErr:          true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/helmt/helmt_test.go
+++ b/pkg/helmt/helmt_test.go
@@ -160,6 +160,7 @@ func TestHelmTemplate(t *testing.T) {
 				filename: "testdata/helm-chart-mandatory-parameters.yaml",
 			},
 			expectedCommands: []string{
+				"helm version",
 				"helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.0.0.tgz",
 				"helm template something --output-dir . jenkins-2.0.0.tgz",
 			},
@@ -170,6 +171,7 @@ func TestHelmTemplate(t *testing.T) {
 				filename: "testdata/helm-chart.yaml",
 			},
 			expectedCommands: []string{
+				"helm version",
 				"helm fetch https://hub.syncier.cloud/chartrepo/library/charts/syncier-jenkins-5.6.0.tgz",
 				"helm template jenkins --namespace jenkins --values values1.yaml --values values2.yaml --output-dir . syncier-jenkins-5.6.0.tgz",
 			},

--- a/pkg/helmt/testdata/helm-chart-empty-namespace.yaml
+++ b/pkg/helmt/testdata/helm-chart-empty-namespace.yaml
@@ -2,3 +2,4 @@ chart: stable/jenkins
 version: 2.0.0
 repository: https://kubernetes-charts.storage.googleapis.com
 namespace:
+name: my-jenkins

--- a/pkg/helmt/testdata/helm-chart-mandatory-parameters.yaml
+++ b/pkg/helmt/testdata/helm-chart-mandatory-parameters.yaml
@@ -1,3 +1,4 @@
 chart: jenkins
 version: 2.0.0
 repository: https://kubernetes-charts.storage.googleapis.com
+name: something

--- a/pkg/helmt/testdata/helm-chart-missing-chart.yaml
+++ b/pkg/helmt/testdata/helm-chart-missing-chart.yaml
@@ -1,2 +1,3 @@
 version: 2.0.0
 repository: https://kubernetes-charts.storage.googleapis.com
+name: jenkins

--- a/pkg/helmt/testdata/helm-chart-missing-repo.yaml
+++ b/pkg/helmt/testdata/helm-chart-missing-repo.yaml
@@ -1,2 +1,3 @@
 chart: jenkins
 version: 2.0.0
+name: jenkins

--- a/pkg/helmt/testdata/helm-chart-missing-version.yaml
+++ b/pkg/helmt/testdata/helm-chart-missing-version.yaml
@@ -1,2 +1,3 @@
 chart: jenkins
 repository: https://kubernetes-charts.storage.googleapis.com
+name: jenkins

--- a/pkg/helmt/testdata/helm-chart.yaml
+++ b/pkg/helmt/testdata/helm-chart.yaml
@@ -1,6 +1,7 @@
 chart: syncier-jenkins
 version: 5.6.0
 repository: https://hub.syncier.cloud/chartrepo/library/charts
+name: jenkins
 namespace: jenkins
 values:
   - values1.yaml


### PR DESCRIPTION
- added mandatory name parameter which is used as release name when running helm template
- use helm-chart.yaml by default if nothing else is specified
- only print helm version, if yaml file could be parsed