### PR TITLE
Render CRDs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@
 
 dist/
 *.tgz
-helmt
+/helmt
 .idea/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then you can run `helmt helm-charts.yaml` and it will download the chart and ren
 helm version
 version.BuildInfo{Version:"v3.1.1", GitCommit:"afe70585407b420d0097d07b21c47dc511525ac8", GitTreeState:"clean", GoVersion:"go1.13.8"}
 helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.0.0.tgz
-helm template jenkins --output-dir . jenkins-2.0.0.tgz
+helm template jenkins jenkins-2.0.0.tgz --output-dir .
 wrote ./jenkins/templates/service-account.yaml
 wrote ./jenkins/templates/secret.yaml
 wrote ./jenkins/templates/config.yaml

--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -28,6 +28,7 @@ type HelmChart struct {
 	Name       string   `yaml:"name" validate:"required"`
 	Namespace  string   `yaml:"namespace"`
 	Values     []string `yaml:"values"`
+	skipCRDs   bool     `yaml:"skipCRDs"`
 }
 
 func readParameters(filename string) (*HelmChart, error) {
@@ -72,17 +73,20 @@ func HelmTemplate(filename string, clean bool) error {
 	}
 
 	chartVersion := fmt.Sprintf("%s-%s.tgz", chart.Chart, chart.Version)
-	return template(chart.Name, chartVersion, chart.Values, chart.Namespace)
+	return template(chart.Name, chartVersion, chart.Values, chart.Namespace, chart.skipCRDs)
 }
 
 func HelmVersion() error {
 	return Execute("helm", "version")
 }
 
-func template(name string, chart string, values []string, namespace string) error {
+func template(name string, chart string, values []string, namespace string, skipCRDs bool) error {
 	args := []string{"template", name, chart}
 	if len(namespace) > 0 {
 		args = append(args, "--namespace", namespace)
+	}
+	if !skipCRDs {
+		args = append(args, "--include-crds")
 	}
 	for _, valuesfile := range values {
 		args = append(args, "--values", valuesfile)

--- a/pkg/helmt/helmt_test.go
+++ b/pkg/helmt/helmt_test.go
@@ -164,7 +164,7 @@ func TestHelmTemplate(t *testing.T) {
 			expectedCommands: []string{
 				"helm version",
 				"helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.0.0.tgz",
-				"helm template something jenkins-2.0.0.tgz --output-dir .",
+				"helm template something jenkins-2.0.0.tgz --include-crds --output-dir .",
 			},
 		},
 		{
@@ -175,7 +175,7 @@ func TestHelmTemplate(t *testing.T) {
 			expectedCommands: []string{
 				"helm version",
 				"helm fetch https://hub.syncier.cloud/chartrepo/library/charts/syncier-jenkins-5.6.0.tgz",
-				"helm template jenkins syncier-jenkins-5.6.0.tgz --namespace jenkins --values values1.yaml --values values2.yaml --output-dir .",
+				"helm template jenkins syncier-jenkins-5.6.0.tgz --namespace jenkins --include-crds --values values1.yaml --values values2.yaml --output-dir .",
 			},
 		},
 		{
@@ -195,7 +195,20 @@ func TestHelmTemplate(t *testing.T) {
 			expectedCommands: []string{
 				"helm version",
 				"helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.0.0.tgz",
-				"helm template something jenkins-2.0.0.tgz --output-dir .",
+				"helm template something jenkins-2.0.0.tgz --include-crds --output-dir .",
+			},
+			wantRemoveOutput: true,
+		},
+		{
+			name: "skip crds",
+			args: args{
+				filename: "testdata/helm-chart-skip-crds.yaml",
+				clean:    true,
+			},
+			expectedCommands: []string{
+				"helm version",
+				"helm fetch https://kubernetes-charts.storage.googleapis.com/jenkins-2.1.0.tgz",
+				"helm template something jenkins-2.1.0.tgz --include-crds --output-dir .",
 			},
 			wantRemoveOutput: true,
 		},

--- a/pkg/helmt/testdata/helm-chart-missing-release.yaml
+++ b/pkg/helmt/testdata/helm-chart-missing-release.yaml
@@ -1,0 +1,3 @@
+chart: syncier-jenkins
+version: 5.6.0
+repository: https://hub.syncier.cloud/chartrepo/library/charts

--- a/pkg/helmt/testdata/helm-chart-skip-crds.yaml
+++ b/pkg/helmt/testdata/helm-chart-skip-crds.yaml
@@ -1,6 +1,5 @@
-chart: stable/jenkins
-version: 2.0.0
+chart: jenkins
+version: 2.1.0
 repository: https://kubernetes-charts.storage.googleapis.com
-namespace:
-name: my-jenkins
+name: something
 skipCRDs: true


### PR DESCRIPTION
add `--include-crds` options when calling `helm template`

This can be disabled by setting `skipCRDs: true` in `helm-chart.yaml`

Signed-off-by: Torsten Walter <torsten.walter@syncier.com>