### PR TITLE
added outputDir config field

### DIFF
--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -33,6 +33,7 @@ type HelmChart struct {
 	Values      []string    `yaml:"values"`
 	SkipCRDs    bool        `yaml:"skipCRDs"`
 	PostProcess PostProcess `yaml:"postProcess"`
+	OutputDir   string      `yaml:"outputDir"`
 }
 
 type PostProcess struct {
@@ -81,7 +82,7 @@ func HelmTemplate(filename string, clean bool) error {
 	}
 
 	chartVersion := fmt.Sprintf("%s-%s.tgz", chart.Chart, chart.Version)
-	err = template(chart.Name, chartVersion, chart.Values, chart.Namespace, chart.SkipCRDs)
+	err = template(chart.Name, chartVersion, chart.Values, chart.Namespace, chart.SkipCRDs, chart.OutputDir)
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func HelmVersion() error {
 	return execute("helm", "version")
 }
 
-func template(name string, chart string, values []string, namespace string, skipCRDs bool) error {
+func template(name string, chart string, values []string, namespace string, skipCRDs bool, outputDir string) error {
 	args := []string{"template", name, chart}
 	if len(namespace) > 0 {
 		args = append(args, "--namespace", namespace)
@@ -109,8 +110,11 @@ func template(name string, chart string, values []string, namespace string, skip
 	for _, valuesfile := range values {
 		args = append(args, "--values", valuesfile)
 	}
-
-	args = append(args, "--output-dir", ".")
+	if len(outputDir) > 0 {
+		args = append(args, "--output-dir", outputDir)
+	} else {
+		args = append(args, "--output-dir", ".")
+	}
 
 	return execute("helm", args...)
 }

--- a/pkg/helmt/helmt_test.go
+++ b/pkg/helmt/helmt_test.go
@@ -247,6 +247,20 @@ func TestHelmTemplate(t *testing.T) {
 			wantRemoveOutput:          true,
 			wantGenerateKustomization: true,
 		},
+		{
+			name: "helm template outputDir in helm-chart.yaml",
+			args: args{
+				filename: "testdata/helm-chart-output-dir.yaml",
+				clean:    true,
+			},
+			expectedCommands: []string{
+				"helm version",
+				"helm fetch --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0 syncier-jenkins",
+				"helm template jenkins syncier-jenkins-5.6.0.tgz --namespace jenkins --include-crds --values values1.yaml --values values2.yaml --output-dir manifests",
+			},
+			wantRemoveOutput:          true,
+			wantGenerateKustomization: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/helmt/testdata/helm-chart-output-dir.yaml
+++ b/pkg/helmt/testdata/helm-chart-output-dir.yaml
@@ -1,0 +1,9 @@
+chart: syncier-jenkins
+version: 5.6.0
+repository: https://hub.syncier.cloud/chartrepo/library
+name: jenkins
+namespace: jenkins
+outputDir: manifests
+values:
+  - values1.yaml
+  - values2.yaml


### PR DESCRIPTION
part-of: AB#2271
## What in this PR
We add output folder in the helm-chart.yaml file schema to be able to output to different than default `.` folder. It will make us able not to refactor our automation code in many places to be compatible with the new argocd version. The only thing which will be needed to adjust `helm-chert.yaml` files, move existing config to new folder and reconfigure argocd applications to read from new location.
## Why we need it?
New version of ArgoCD according to the ticket AB#2271 fails to work with the current repository structure. In order to be able to upgrade - we need to adjust a repo structure to have k8s manifest in a folder which does not contain other non-kubernetes files.