### PR TITLE
Support authorization for helm fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Usage:
   helmt <filename> [flags]
 
 Flags:
-      --clean           delete existing templates before rendering
-      --config string   config file (default is $HOME/.helmt.yaml)
-  -h, --help            help for helmt
-  -v, --version         version for helmt
+      --clean             delete existing templates before rendering
+      --config string     config file (default is $HOME/.helmt.yaml)
+  -h, --help              help for helmt
+      --password string   optional password for chart repository
+      --username string   optional username for chart repository
+  -v, --version           version for helmt
 ```
 
 ## Example
@@ -58,3 +60,5 @@ wrote ./jenkins/templates/jenkins-agent-svc.yaml
 wrote ./jenkins/templates/jenkins-master-svc.yaml
 wrote ./jenkins/templates/jenkins-master-deployment.yaml
 ```
+
+If the chart repository needs authentication, provide credentials via `--username` and `--password`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,14 +19,18 @@ import (
 	"fmt"
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/syncier/helmt/pkg/helmt"
 )
 
-var cfgFile string
-var clean bool
+var (
+	cfgFile  string
+	clean    bool
+	username string
+	password string
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "helmt <filename>",
@@ -57,7 +61,7 @@ namespace, values, skipCRDs apiVersions and postProcess are optional
 		}
 		fmt.Printf("templating '%s'\n", filename)
 
-		return helmt.HelmTemplate(filename, clean)
+		return helmt.HelmTemplate(filename, clean, username, password)
 	},
 }
 
@@ -71,12 +75,10 @@ func Execute(version string) error {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.helmt.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&clean, "clean", false, "delete existing templates before rendering")
+	rootCmd.PersistentFlags().StringVar(&username, "username", "", "optional username for chart repository")
+	rootCmd.PersistentFlags().StringVar(&password, "password", "", "optional password for chart repository")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -60,7 +60,7 @@ func readParameters(filename string) (*HelmChart, error) {
 	return chart, nil
 }
 
-func HelmTemplate(filename string, clean bool) error {
+func HelmTemplate(filename string, clean bool, username, password string) error {
 	chart, err := readParameters(filename)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func HelmTemplate(filename string, clean bool) error {
 		return err
 	}
 
-	err = fetch(chart.Repository, chart.Chart, chart.Version)
+	err = fetch(chart.Repository, chart.Chart, chart.Version, username, password)
 	if err != nil {
 		return err
 	}
@@ -129,8 +129,18 @@ func template(name string, chart string, values []string, namespace string, skip
 	return execute("helm", execOpts{}, args...)
 }
 
-func fetch(repository, chart, version string) error {
-	return execute("helm", execOpts{}, "fetch", "--repo", repository, "--version", version, chart)
+func fetch(repository, chart, version string, username, password string) error {
+	args := []string{"fetch"}
+	args = append(args, "--repo", repository)
+	args = append(args, "--version", version)
+	if username != "" {
+		args = append(args, "--username", username)
+	}
+	if password != "" {
+		args = append(args, "--password", password)
+	}
+	args = append(args, chart)
+	return execute("helm", execOpts{}, args...)
 }
 
 type execOpts struct {


### PR DESCRIPTION
This PR enables support for chart repositories that are not public. If they need authentication, credentials can now be provided via `--username` and `--password`.
