### PR TITLE
OCI format and temporary backward compatibility

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	configFlag   = "config"
+	cleanFlag    = "clean"
 	usernameFlag = "username"
 	passwordFlag = "password"
 )
@@ -77,6 +78,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().String(configFlag, "", "config file (default is $HOME/.helmt.yaml)")
+	rootCmd.PersistentFlags().Bool(cleanFlag, false, "deprecated flag - cleaning is done by default")
 	rootCmd.PersistentFlags().StringP(usernameFlag, "u", "", "optional username for chart repository")
 	rootCmd.PersistentFlags().StringP(passwordFlag, "p", "", "optional password for chart repository")
 

--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -2,7 +2,6 @@ package helmt
 
 import (
 	"fmt"
-	"github.com/spf13/afero"
 	"io"
 	"io/ioutil"
 	"os"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/go-playground/validator/v10"
+	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )

--- a/pkg/helmt/helmt.go
+++ b/pkg/helmt/helmt.go
@@ -149,8 +149,16 @@ func template(tmpDir string, name string, chart string, values []string, namespa
 }
 
 func fetch(tmpDir, repository, chart, version string, username, password string) (string, error) {
+	isOCI := strings.HasPrefix(repository, "oci://")
+	if isOCI {
+		repository = strings.Join([]string{repository, chart}, "/")
+	}
+
 	args := []string{"fetch"}
-	args = append(args, "--repo", repository)
+	if !isOCI {
+		args = append(args, "--repo")
+	}
+	args = append(args, repository)
 	args = append(args, "--version", version)
 	args = append(args, "--destination", tmpDir)
 	if username != "" {
@@ -159,7 +167,10 @@ func fetch(tmpDir, repository, chart, version string, username, password string)
 	if password != "" {
 		args = append(args, "--password", password)
 	}
-	args = append(args, chart)
+
+	if !isOCI {
+		args = append(args, chart)
+	}
 	err := execute("helm", execOpts{}, args...)
 	if err != nil {
 		return "", err

--- a/pkg/helmt/helmt_test.go
+++ b/pkg/helmt/helmt_test.go
@@ -2,8 +2,6 @@ package helmt
 
 import (
 	"fmt"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/otiai10/copy"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func NewTestExecutor(t *testing.T) *testExecutor {
@@ -277,6 +277,18 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://kubernetes-charts.storage.googleapis.com --version 2.0.0 --destination /temp/helmt-123 --username user --password pass jenkins",
 				"helm template something /temp/helmt-123/chart-1.0.0.tgz --include-crds --skip-tests --output-dir /temp/helmt-123",
+			},
+		},
+		{
+			name:        "helm template using OCI repo format",
+			releaseName: "syncier-jenkins",
+			args: args{
+				filename: "testdata/helm-chart-oci-repo.yaml",
+			},
+			expectedCommands: []string{
+				"helm version",
+				"helm fetch oci://acrsycprodfrc1platform.azurecr.io/charts/syncier-jenkins --version 8.8.3 --destination /temp/helmt-123",
+				"helm template jenkins /temp/helmt-123/chart-1.0.0.tgz --include-crds --skip-tests --output-dir /temp/helmt-123",
 			},
 		},
 	}

--- a/pkg/helmt/helmt_test.go
+++ b/pkg/helmt/helmt_test.go
@@ -191,6 +191,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://kubernetes-charts.storage.googleapis.com --version 2.0.0 --destination /temp/helmt-123 jenkins",
 				"helm template something /temp/helmt-123/chart-1.0.0.tgz --include-crds --skip-tests --output-dir /temp/helmt-123",
+				"helm show chart jenkins --repo https://kubernetes-charts.storage.googleapis.com --version 2.0.0",
 			},
 		},
 		{
@@ -203,6 +204,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0 --destination /temp/helmt-123 syncier-jenkins",
 				"helm template jenkins /temp/helmt-123/chart-1.0.0.tgz --namespace jenkins --include-crds --skip-tests --values values1.yaml --values values2.yaml --output-dir /temp/helmt-123",
+				"helm show chart syncier-jenkins --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0",
 			},
 		},
 		{
@@ -224,6 +226,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://kubernetes-charts.storage.googleapis.com --version 2.1.0 --destination /temp/helmt-123 jenkins",
 				"helm template something /temp/helmt-123/chart-1.0.0.tgz --skip-tests --output-dir /temp/helmt-123",
+				"helm show chart jenkins --repo https://kubernetes-charts.storage.googleapis.com --version 2.1.0",
 			},
 		},
 		{
@@ -236,6 +239,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://kubernetes-charts.storage.googleapis.com --version 8.12.15 --destination /temp/helmt-123 prometheus-operator",
 				"helm template agent-prometheus /temp/helmt-123/chart-1.0.0.tgz --namespace infra-monitoring --include-crds --skip-tests --values prometheus-operator-values.yaml --output-dir /temp/helmt-123",
+				"helm show chart prometheus-operator --repo https://kubernetes-charts.storage.googleapis.com --version 8.12.15",
 			},
 			wantGenerateKustomization: true,
 		},
@@ -249,6 +253,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0 --destination /temp/helmt-123 syncier-jenkins",
 				"helm template jenkins /temp/helmt-123/chart-1.0.0.tgz --namespace jenkins --include-crds --skip-tests --values values1.yaml --values values2.yaml --output-dir /temp/helmt-123",
+				"helm show chart syncier-jenkins --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0",
 			},
 			wantGenerateKustomization: false,
 		},
@@ -262,6 +267,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0 --destination /temp/helmt-123 syncier-jenkins",
 				"helm template jenkins /temp/helmt-123/chart-1.0.0.tgz --namespace jenkins --include-crds --skip-tests --values values1.yaml --values values2.yaml --output-dir /temp/helmt-123 --api-versions monitoring.coreos.com/v1 --api-versions monitoring.coreos.com/v1alpha1",
+				"helm show chart syncier-jenkins --repo https://hub.syncier.cloud/chartrepo/library --version 5.6.0",
 			},
 			wantGenerateKustomization: false,
 		},
@@ -277,6 +283,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch --repo https://kubernetes-charts.storage.googleapis.com --version 2.0.0 --destination /temp/helmt-123 --username user --password pass jenkins",
 				"helm template something /temp/helmt-123/chart-1.0.0.tgz --include-crds --skip-tests --output-dir /temp/helmt-123",
+				"helm show chart jenkins --repo https://kubernetes-charts.storage.googleapis.com --version 2.0.0",
 			},
 		},
 		{
@@ -289,6 +296,7 @@ func TestHelmTemplate(t *testing.T) {
 				"helm version",
 				"helm fetch oci://acrsycprodfrc1platform.azurecr.io/charts/syncier-jenkins --version 8.8.3 --destination /temp/helmt-123",
 				"helm template jenkins /temp/helmt-123/chart-1.0.0.tgz --include-crds --skip-tests --output-dir /temp/helmt-123",
+				"helm show chart oci://acrsycprodfrc1platform.azurecr.io/charts/syncier-jenkins --version 8.8.3",
 			},
 		},
 	}

--- a/pkg/helmt/testdata/helm-chart-oci-repo.yaml
+++ b/pkg/helmt/testdata/helm-chart-oci-repo.yaml
@@ -1,0 +1,4 @@
+chart: syncier-jenkins
+version: 8.8.3
+repository: oci://acrsycprodfrc1platform.azurecr.io/charts
+name: jenkins


### PR DESCRIPTION
### Change description


- Adds `--clean` flag back and downloads the `Chart.yaml` file to maintain backward compatibility with the version used by our pipeline image https://github.com/syncier/image-pipeline/blob/1cf2294627564fce578b14740cfdc9bf1fb8e1da/Dockerfile#L9.
  - We can remove the clean flag after we fix the pipelines (eg: https://github.com/syncier/platform-bootstrap/blob/f3577e4d9a60574fbcadf7ed15fe0e7bf7b650f3/argocd/main.tf#L169).
  - According to https://github.com/syncier/securitytower-server/pull/1522#pullrequestreview-832999380, `Chart.yaml` is not used in the securitytower anymore. In the next iteration we can decide to remove this as well.

- Adds OCI format support to migrate pipeline images from Jenkins to the azure container registry.
  - Pull image from ACR:
`helm pull oci://acrsycprodfrc1platform.azurecr.io/charts/syncier-jenkins --version 8.8.3`
  - Pull image from Harbor (hard-coded in the tool):
`helm pull --repo https://hub.syncier.cloud/chartrepo/library --version 8.8.3 --destination ./ syncier-jenkins`

### User Story/Bug

- [AB#11846](https://dev.azure.com/syncier/cloud/_boards/board/t/Platform/Stories/?workitem=11846)

### Change type

- [x] Bugfix
- [x] New feature
- [ ] Breaking change

### Checklist

- [ ] Self-review performed
- [ ] Documentation changes made
